### PR TITLE
wip: 파일 리스트  불러오기(UI) & 논리적 서버 오류 수정

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,12 +1,21 @@
 import '@app/config/style/global.css';
 import { RouterProvider } from '@app/config/router';
 import { ModalProvider } from '@shared/ui';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {},
+  },
+});
 
 const App = () => {
   return (
-    <ModalProvider>
-      <RouterProvider />
-    </ModalProvider>
+    <QueryClientProvider client={queryClient}>
+      <ModalProvider>
+        <RouterProvider />
+      </ModalProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/app/src/features/ScrollEndObserver/index.tsx
+++ b/app/src/features/ScrollEndObserver/index.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode, useEffect, useRef } from 'react';
+
+type Props = {
+  children: ReactNode;
+  onScrollEnd: () => void;
+};
+
+const ScrollEndObserver: React.FC<Props> = ({ children, onScrollEnd }) => {
+  const root = useRef<HTMLDivElement>(null);
+  const anchor = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!anchor.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        console.log('intersecting!');
+        onScrollEnd();
+      },
+      {
+        root: root.current,
+      },
+    );
+
+    observer.observe(anchor.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={root} className="h-full w-full ObserverRoot">
+      {children}
+      <div id="scrollAnchor" className="w-full h-[1px]" ref={anchor} />
+    </div>
+  );
+};
+
+export default ScrollEndObserver;

--- a/app/src/features/layout/Mobile.tsx
+++ b/app/src/features/layout/Mobile.tsx
@@ -15,8 +15,10 @@ export const Mobile: React.FC<Props> = ({ header, children }) => {
       <Outlet />
       <AppLayout>
         <Header children={header} />
-        <article className="flex flex-col flex-1 flex-shrink-0">
-          <article className="col flex-1 h-full p-[16px]">{children}</article>
+        <article className="flex flex-col flex-1 flex-shrink-0 max-h-full overflow-auto">
+          <article className="col flex-1 p-[16px] overflow-y-scroll">
+            {children}
+          </article>
           <GNB />
         </article>
       </AppLayout>

--- a/app/src/features/upload-box/api/index.ts
+++ b/app/src/features/upload-box/api/index.ts
@@ -1,0 +1,28 @@
+import { apiClient } from '@shared/config';
+import { UploadBoxDetails } from '@entities/upload-box';
+import qs from 'query-string';
+
+export type BoxSummary = {
+  id: number;
+  uploader: string;
+  title: string;
+  fileSize: number;
+  crypted: boolean;
+};
+
+export type BoxListRequestParam = {
+  cursor?: number;
+  keyword?: string;
+  type?: string;
+};
+
+export type BoxListResponse = {
+  boxes: UploadBoxDetails[];
+  nextCursorId: number | -1;
+};
+
+export const getBoxList = async (
+  params: BoxListRequestParam,
+): Promise<BoxListResponse> => apiClient.get(`/boxes?${qs.stringify(params)}`);
+
+export { default as useBoxesQuery } from './useBoxesQuery';

--- a/app/src/features/upload-box/api/useBoxesQuery.tsx
+++ b/app/src/features/upload-box/api/useBoxesQuery.tsx
@@ -1,0 +1,62 @@
+import { create } from 'zustand/react';
+import {
+  useQuery,
+  keepPreviousData,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
+import { getBoxList } from './index';
+import { UploadBoxDetails } from '@entities/upload-box';
+
+type StoreStates = {
+  keyword?: string;
+  setKeyword: (keyword?: string) => void;
+  type?: 'nickname' | 'title';
+  changeSearchType: (type?: 'nickname' | 'title') => void;
+  cursor?: number | -1;
+  setNextCursor: (cursor: number | -1) => void;
+};
+
+const useStore = create<StoreStates>((set, get) => ({
+  setKeyword: (keyword) => set({ keyword }),
+  changeSearchType: (type) => set({ type }),
+  setNextCursor: (cursor) => set({ cursor }),
+}));
+
+const useBoxesQuery = () => {
+  const { keyword, type } = useStore();
+
+  const { data, fetchNextPage, ...query } = useInfiniteQuery({
+    queryKey: ['box-list', keyword, type],
+    queryFn: ({ pageParam }) =>
+      getBoxList({
+        keyword,
+        type,
+        cursor: pageParam,
+      }),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursorId,
+  });
+
+  const boxes = (() => {
+    if (!data) return [] as UploadBoxDetails[];
+    return data.pages.map((page) => page.boxes).flat();
+  })();
+
+  const dataReturns = {
+    boxes,
+    keyword,
+    type,
+  };
+
+  const getNextData = () => {
+    fetchNextPage();
+  };
+
+  return {
+    data: dataReturns,
+    query,
+    getNextData,
+  };
+};
+
+export default useBoxesQuery;

--- a/app/src/features/upload-box/index.tsx
+++ b/app/src/features/upload-box/index.tsx
@@ -1,3 +1,4 @@
 export * from './ui/search';
 export * from './ui/card';
 export * from './ui/list';
+export * from './api';

--- a/app/src/features/upload-box/ui/card/ui/Details.tsx
+++ b/app/src/features/upload-box/ui/card/ui/Details.tsx
@@ -1,22 +1,28 @@
 import React from 'react';
-import { UploadBoxDetails } from "@entities/upload-box";
-import { Icon, Typo } from "@shared/ui";
+import { UploadBoxDetails } from '@entities/upload-box';
+import { Icon, Typo } from '@shared/ui';
 
-type Props = Pick<UploadBoxDetails, "uploader" | "title">
+type Props = Pick<UploadBoxDetails, 'uploader' | 'title'>;
 
 const Details: React.FC<Props> = ({ uploader, title }) => {
   return (
     <div className="flex items-center gap-x-[8px]">
       <Icon.BlueFile />
       <div className="flex flex-col">
-        <Typo size={14} bold>{title}</Typo>
+        <Typo size={14} bold>
+          {title}
+        </Typo>
         <div className="flex gap-x-1">
-          <Typo size={9} color="gray" bold>업로더</Typo>
-          <Typo size={9} color="light-blue" bold>{uploader}</Typo>
+          <Typo size={11} color="gray" bold>
+            업로더
+          </Typo>
+          <Typo size={11} color="light-blue" bold>
+            {uploader}
+          </Typo>
         </div>
       </div>
     </div>
   );
-}
+};
 
 export default Details;

--- a/app/src/features/upload-box/ui/list/index.tsx
+++ b/app/src/features/upload-box/ui/list/index.tsx
@@ -1,17 +1,27 @@
 import React from 'react';
-import { UploadBoxDetails } from '@entities/upload-box';
 import UploadBox from '../card';
+import { useBoxesQuery } from '@features/upload-box';
+import ScrollEndObserver from '@features/ScrollEndObserver';
 
-type Props = {
-  data: UploadBoxDetails[];
-};
+export const UploadBoxList: React.FC = () => {
+  const {
+    data: { boxes },
+    getNextData,
+  } = useBoxesQuery();
 
-export const UploadBoxList: React.FC<Props> = ({ data }) => {
+  const test = () => {
+    getNextData();
+  };
+
+  console.log({ boxes });
+
   return (
-    <div className="flex flex-col gap-y-[8px] overflow-y-scroll">
-      {data.map((box) => (
-        <UploadBox key={box.id} data={box} />
-      ))}
-    </div>
+    <ScrollEndObserver onScrollEnd={test}>
+      <div className="flex flex-col gap-y-[8px]">
+        {boxes.map((box) => (
+          <UploadBox key={box.id} data={box} />
+        ))}
+      </div>
+    </ScrollEndObserver>
   );
 };

--- a/app/src/pages/home/ui/page.tsx
+++ b/app/src/pages/home/ui/page.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 import { Mobile } from '@features/layout';
 import DashboardPanel from '@widgets/dashboard-panel';
-import { Search, UploadBoxList } from '@features/upload-box';
-import { mockUploadBox } from '@entities/upload-box';
+import { Search, UploadBoxList, useBoxesQuery } from '@features/upload-box';
 
 export const Home: React.FC = () => {
-  const data = Array.from({ length: 10 }, () => ({ ...mockUploadBox }));
+  const {
+    query: { isFetched },
+  } = useBoxesQuery();
+
+  if (!isFetched) return null;
 
   return (
     <Mobile header="header-logo">
       <DashboardPanel />
       <Search />
-      <UploadBoxList data={data} />
+      <UploadBoxList />
     </Mobile>
   );
 };

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/BoxController.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/BoxController.java
@@ -1,8 +1,7 @@
 package com.hbu.hanbatbox.controller;
 
-import com.hbu.hanbatbox.dto.BoxGetDto;
+import com.hbu.hanbatbox.controller.dto.BoxListDetails;
 import com.hbu.hanbatbox.dto.BoxSaveDto;
-import com.hbu.hanbatbox.dto.Result;
 import com.hbu.hanbatbox.service.BoxService;
 
 import java.util.List;
@@ -26,12 +25,12 @@ public class BoxController {
   private final BoxService boxService;
 
   @GetMapping
-  public ResponseEntity<Result<List<BoxGetDto>>> getAllBoxes(
+  public ResponseEntity<BoxListDetails> getAllBoxes(
       @RequestParam(required = false) Long cursor, @RequestParam(required = false) String keyword,
       @RequestParam(required = false) String type) {
 
-    List<BoxGetDto> boxes = boxService.searchBoxes(keyword, type, cursor);
-    return ResponseEntity.ok(new Result<>(200, "Success", boxes));
+    BoxListDetails boxListDetails = boxService.searchBoxes(keyword, type, cursor);
+    return ResponseEntity.ok(boxListDetails);
   }
 
   @PostMapping(value = "/uploads", consumes = {MediaType.APPLICATION_JSON_VALUE,

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/dto/BoxListDetails.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/dto/BoxListDetails.java
@@ -1,0 +1,10 @@
+package com.hbu.hanbatbox.controller.dto;
+
+import com.hbu.hanbatbox.dto.BoxGetDto;
+
+import java.util.List;
+
+public record BoxListDetails(
+    List<BoxGetDto> boxes,
+    Long nextCursorId
+) {}

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/repository/BoxRepository.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/repository/BoxRepository.java
@@ -3,6 +3,8 @@ package com.hbu.hanbatbox.repository;
 import com.hbu.hanbatbox.domain.Box;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BoxRepository extends JpaRepository<Box, Long> {
 
@@ -13,4 +15,10 @@ public interface BoxRepository extends JpaRepository<Box, Long> {
     List<Box> findTop5ByTitleContainingOrderByIdDesc(String title);
 
     List<Box> findTop5ByTitleContainingAndIdLessThanOrderByIdDesc(String title, Long id);
+
+    @Query("SELECT b FROM Box as b WHERE (:id is null or b.id < :id) ORDER BY b.id DESC LIMIT 10")
+    List<Box> findByCursor(@Param("id") Long id);
+
+    @Query("SELECT b.id FROM Box as b WHERE b.id = :currentId - 1")
+    Long getNextId(@Param("currentId") Long id);
 }


### PR DESCRIPTION
## Backlog
`none`

## Description
* 서버에서 데이터가 조회되지 않는 이슈를 해결하였습니다.
> 정상 동작 여부의 위험성 검증 X

* 커서 방식 페이지네이션의 다음 커서 정보를 추가하였습니다.
* 최초 페이지에서 데이터를 불러와 로드하는 기능을 추가하였습니다.

### ScreenShots (Optional)
https://github.com/user-attachments/assets/2ce57f36-141a-43fd-9732-4d7c32a84e7e


## Checks
- [ ] [노션 In Progress -> Done 변경](https://www.notion.so/BOX-11518d349b95807c9b07d6cb10be5b07?pvs=4)
