### PR TITLE
[fix]: 다운로드 API 패스워드 없으면 빈 문자열 처리

### DIFF
--- a/hanbatbox-api/build.gradle
+++ b/hanbatbox-api/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-security'
+  implementation 'org.springframework.boot:spring-boot-starter-validation'
   compileOnly 'org.projectlombok:lombok'
   runtimeOnly 'org.postgresql:postgresql'
   annotationProcessor 'org.projectlombok:lombok'

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/BoxController.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/BoxController.java
@@ -3,9 +3,8 @@ package com.hbu.hanbatbox.controller;
 import com.hbu.hanbatbox.controller.dto.BoxListDetails;
 import com.hbu.hanbatbox.dto.BoxSaveDto;
 import com.hbu.hanbatbox.service.BoxService;
-
+import jakarta.validation.Valid;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +34,7 @@ public class BoxController {
 
   @PostMapping(value = "/uploads", consumes = {MediaType.APPLICATION_JSON_VALUE,
       MediaType.MULTIPART_FORM_DATA_VALUE})
-  public ResponseEntity<Long> uploads(@RequestPart BoxSaveDto data,
+  public ResponseEntity<Long> uploads(@Valid @RequestPart BoxSaveDto data,
                                       @RequestPart(name = "files") List<MultipartFile> files) {
 
     Long boxId = boxService.saveBoxWithItems(data, files);

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/S3Controller.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/S3Controller.java
@@ -27,7 +27,7 @@ public class S3Controller {
       @RequestBody Map<String, String> data,
       HttpServletResponse response) throws IOException {
 
-    String inputPassword = data.get("password");
+    String inputPassword = data.getOrDefault("password", "");
     if (!s3Service.validatePassword(id, inputPassword)) {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid password");
     }

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/dto/BoxSaveDto.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/dto/BoxSaveDto.java
@@ -1,5 +1,7 @@
 package com.hbu.hanbatbox.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,6 +11,9 @@ public class BoxSaveDto {
 
     private String uploader;
     private String title;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 4, message = "비밀번호는 최소 4자 이상이어야 합니다.")
     private String password;
 }
 

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/exception/GlobalExceptionHandler.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/exception/GlobalExceptionHandler.java
@@ -1,11 +1,15 @@
 package com.hbu.hanbatbox.exception;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-
-import java.io.IOException;
+import org.springframework.web.server.ResponseStatusException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -28,5 +32,34 @@ public class GlobalExceptionHandler {
     // logging
     ex.printStackTrace();
     return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+    Map<String, String> errors = new HashMap<>();
+
+    for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+      errors.put(error.getField(), error.getDefaultMessage());
+    }
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+  }
+
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<Map<String, Object>> handleResponseStatusException(ResponseStatusException ex) {
+    Map<String, Object> errorDetails = new HashMap<>();
+    errorDetails.put("status", ex.getStatusCode().value());
+    errorDetails.put("error", ex.getReason());
+
+    return new ResponseEntity<>(errorDetails, ex.getStatusCode());
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
+    Map<String, Object> errorDetails = new HashMap<>();
+    errorDetails.put("status", HttpStatus.BAD_REQUEST.value());
+    errorDetails.put("error", ex.getMessage());
+
+    return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
   }
 }

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/repository/BoxRepository.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/repository/BoxRepository.java
@@ -3,8 +3,6 @@ package com.hbu.hanbatbox.repository;
 import com.hbu.hanbatbox.domain.Box;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface BoxRepository extends JpaRepository<Box, Long> {
     List<Box> findTop5ByTitleContainingOrderByIdDesc(String title);

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/service/BoxService.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/service/BoxService.java
@@ -14,7 +14,6 @@ import jakarta.persistence.criteria.Root;
 import jakarta.transaction.Transactional;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/service/S3Service.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/service/S3Service.java
@@ -61,6 +61,11 @@ public class S3Service {
   }
 
   private String createObjectKey(String title, String originFileName) {
+
+    if (originFileName == null || !originFileName.contains(".")) {
+      throw new IllegalArgumentException("올바른 파일을 추가해 주세요.");
+    }
+
     String extension = originFileName.split("\\.")[1];
     return "%d-%s.%s".formatted(System.currentTimeMillis(), title, extension);
   }

--- a/hanbatbox-api/src/main/resources/application.yml
+++ b/hanbatbox-api/src/main/resources/application.yml
@@ -29,6 +29,10 @@ spring:
       file-size-threshold: 0B
       max-file-size: 2GB
       max-request-size: 2GB
+  security:
+    user:
+      name: ${SECURITY_USER}
+      password: ${SECURITY_PASSWORD}
 server:
   servlet:
     context-path: /api


### PR DESCRIPTION
## Backlog
[WD-54](https://www.notion.so/BOX-11518d349b95807c9b07d6cb10be5b07?p=2c63a98fc1504bf494a1c9bf8832b264&pm=s)

## Description

- 다운로드 API로 받은 데이터에서 패스워드 없으면 빈 문자열 처리했습니다.
- This generated password is for development use only 문구 안 뜨게 시큐리티 유저 패스워드 정보 추가했습니다.
   환경 변수에 SECURITY_USER, SECURITY_PASSWORD 추가해주세요!
- 업로드 시 패스워드 유효성 검사 추가했습니다 (4자 이상)
- 파일 없이 업로드하는 경우, 패스워드 불일치 글로벌 예외 처리
- 사용하지 않는 임포트 제거


### ScreenShots (Optional)


## Checks
- [ ] [노션 In Progress -> Done 변경](https://www.notion.so/BOX-11518d349b95807c9b07d6cb10be5b07?pvs=4)
