### PR TITLE
Refactor/#WD-55 다운로드 기능 리팩터링

### DIFF
--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/dto/Password.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/dto/Password.java
@@ -1,0 +1,3 @@
+package com.hbu.hanbatbox.controller.dto;
+
+public record Password(String password) {}

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/dto/S3FileDetails.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/controller/dto/S3FileDetails.java
@@ -1,0 +1,3 @@
+package com.hbu.hanbatbox.controller.dto;
+
+public record S3FileDetails(String fileName, long size, byte[] content) {}

--- a/hanbatbox-api/src/main/java/com/hbu/hanbatbox/service/DownloadResponseBuilder.java
+++ b/hanbatbox-api/src/main/java/com/hbu/hanbatbox/service/DownloadResponseBuilder.java
@@ -1,0 +1,23 @@
+package com.hbu.hanbatbox.service;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class DownloadResponseBuilder {
+
+  public static org.springframework.http.HttpHeaders getResponseHeader(String title, long size) {
+    HttpHeaders headers = new HttpHeaders();
+    String encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8);
+
+    headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+    headers.setContentLength(size);
+    headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + encodedTitle);
+    headers.add("Content-Transfer-Encoding", "binary");
+
+    return headers;
+  }
+
+}


### PR DESCRIPTION
## Backlog
### #WD-55

## Description
* `ServletResponse` 객체를 직접 참조하는 방식에서 `ResponseEntity` 를 반환하는 구조로 설계를 변경하였습니다.
* `S3Controller` 와 `S3Service` 객체 간의 책임을 적절하게 분리하였습니다. (`Single Responsibility Principle`)
* 몇몇 로직의 재사용 부분을 공통화 하였습니다.
* 특정 로직의 분기 처리를 서비스 내에서 중앙 처리하게 끔 구조를 수정하였습니다.
* 응답 헤더를  반환하는 유틸 클래스를 작성하였습니다.

## 문제
* 현재 zip 파일 (다중 다운로드) 의 경우 예상 시간 한도를 초과하여 연산이 수행되는 문제가 발생 중입니다.
대회 일자가 얼마 안남은 시점에서 프런트 기능 개발에 집중해야하기때문에 백엔드 두 분께서 해당 문제 해결을 진행해주시면 감사드리겠습니다...!

> 더 이상 싱글 다운로드는 문제가 없습니다.

## Checks
- [x] [노션 In Progress -> Done 변경](https://www.notion.so/BOX-11518d349b95807c9b07d6cb10be5b07?pvs=4)
